### PR TITLE
FIX: Remove update_attributes which is deprecated in Rails 6.0.0

### DIFF
--- a/spec/controllers/user_card_badge_controller_spec.rb
+++ b/spec/controllers/user_card_badge_controller_spec.rb
@@ -19,7 +19,7 @@ describe UserCardBadges::UserCardBadgeController do
 
       expect(user.reload.custom_fields['card_image_badge_id']).to be_blank
 
-      badge.update_attributes image: "wat.com/wat.jpg"
+      badge.update image: "wat.com/wat.jpg"
 
       put :update, params: {
         user_badge_id: user_badge.id, username: user.username


### PR DESCRIPTION
An easy fix to remove the warning in Rails 6.0.0