### PR TITLE
DEV: Compatibility with the deprecation of the image column on the badges table

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,0 +1,1 @@
+2.7.0.beta4: b14e27b8ed3e9b2b7da0c7c643789b8281df94f1

--- a/plugin.rb
+++ b/plugin.rb
@@ -66,7 +66,7 @@ after_initialize do
       guardian.ensure_can_edit!(user)
 
       user_badge = UserBadge.find_by(id: params[:user_badge_id].to_i)
-      if user_badge && user_badge.user == user && user_badge.badge.image.present?
+      if user_badge && user_badge.user == user && user_badge.badge.image_upload.present?
         current_user.custom_fields['card_image_badge_id'] = user_badge.badge.id
       else
         current_user.custom_fields['card_image_badge_id'] = nil

--- a/spec/controllers/user_card_badge_controller_spec.rb
+++ b/spec/controllers/user_card_badge_controller_spec.rb
@@ -19,7 +19,7 @@ describe UserCardBadges::UserCardBadgeController do
 
       expect(user.reload.custom_fields['card_image_badge_id']).to be_blank
 
-      badge.update image: "wat.com/wat.jpg"
+      badge.update!(image_upload_id: Fabricate(:upload).id)
 
       put :update, params: {
         user_badge_id: user_badge.id, username: user.username


### PR DESCRIPTION
This PR makes this plugin compatible with latest core changes in https://github.com/discourse/discourse/pull/12377. This should be merged only after the core PR is merged.