### PR TITLE
FIX: image column is now image_upload in core

### DIFF
--- a/assets/javascripts/discourse/controllers/preferences-card-badge.js.es6
+++ b/assets/javascripts/discourse/controllers/preferences-card-badge.js.es6
@@ -26,7 +26,7 @@ export default Controller.extend({
 
   @computed("saving")
   savingStatus(saving) {
-    return saving ? I18n.t("saving") : I18n.t("save");
+    return saving ? "saving" : "save";
   },
 
   @computed("selectedUserBadgeId")

--- a/assets/javascripts/discourse/routes/preferences-card-badge.js.es6
+++ b/assets/javascripts/discourse/routes/preferences-card-badge.js.es6
@@ -24,7 +24,7 @@ export default RestrictedUserRoute.extend({
 
     model.forEach(function (userBadge) {
       if (
-        userBadge.get("badge.image") === controller.get("user.card_image_badge")
+        userBadge.get("badge.id") === controller.get("user.card_image_badge_id")
       ) {
         controller.set("selectedUserBadgeId", userBadge.get("id"));
       }

--- a/assets/javascripts/discourse/templates/connectors/user-preferences-profile/user-card-badges.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-preferences-profile/user-card-badges.hbs
@@ -4,7 +4,7 @@
     <div class="controls">
       <div class="card-image-preview">
         {{#if model.card_image_badge}}
-          <img src={{model.card_image_badge}} alt={{user.card_badge.name}}>
+          <img src={{model.card_image_badge.url}} alt={{user.card_badge.name}}>
         {{else}}
           {{i18n "user.card_badge.none"}}
         {{/if}}

--- a/plugin.rb
+++ b/plugin.rb
@@ -37,7 +37,7 @@ after_initialize do
   end
 
   add_to_serializer(:user, :card_image_badge, false) do
-    card_badge&.image
+    card_badge&.image_upload
   end
 
   add_to_serializer(:user, :card_image_badge_id) do

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ::UserCardBadges do
+  let(:user) { Fabricate(:user) }
+  let(:badge) { Fabricate(:badge) }
+  let(:image_upload) { Fabricate(:image_upload) }
+
+  before do
+    SiteSetting.user_card_badges_enabled = true
+    UserCustomField.create!(user_id: user.id, name: 'card_image_badge_id', value: badge.id)
+    user.reload
+  end
+
+  it "adds card_badge to the UserCardSerializer" do
+    serializer = UserCardSerializer.new(user)
+    expect(serializer.card_badge).to eq(user.card_image_badge)
+    expect(user.card_image_badge_id.to_i).to eq(badge.id)
+  end
+
+  it "adds card_image_badge to the UserSerializer if there is an image on the badge" do
+    serializer = UserSerializer.new(user)
+    expect(serializer.card_image_badge).to eq(nil)
+    badge.update(image_upload: image_upload)
+    expect(serializer.card_image_badge).to eq(image_upload)
+  end
+end


### PR DESCRIPTION
This was causing errors in the UserSerializer when
we were calling card_image_badge.

See also: https://meta.discourse.org/t/since-2-8-0beta2-update-some-users-cant-get-to-preferences-etc/193952