### PR TITLE
DEV: Upgrade modifyClass syntax to remove object-literal decorators

### DIFF
--- a/assets/javascripts/discourse/initializers/initialize-user-card-badges.js
+++ b/assets/javascripts/discourse/initializers/initialize-user-card-badges.js
@@ -1,17 +1,20 @@
-import computed from "discourse/lib/decorators";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
 function modifyUserCardContents(api) {
-  api.modifyClass("component:user-card-contents", {
-    pluginId: "discourse-user-card-badges",
-
-    classNameBindings: ["hasCardBadgeImage"],
-
-    @computed("user.card_badge.image")
-    hasCardBadgeImage(image) {
-      return image && image.indexOf("fa-") !== 0;
-    },
-  });
+  api.modifyClass(
+    "component:user-card-contents",
+    (Superclass) =>
+      class extends Superclass {
+        get classNames() {
+          const result = [...super.classNames];
+          const image = this.user.card_badge?.image;
+          if (image && !image.includes("fa-")) {
+            result.push("has-card-badge-image");
+          }
+          return result;
+        }
+      }
+  );
 }
 
 export default {


### PR DESCRIPTION
Decorators on object literal properties are unsupported in most modern JS tooling, including ts/glint and Prettier 3.0. Using the new native-class-based modifyClass syntax means we can use decorators safely